### PR TITLE
Fixed Decline Button's layout_toRightOf attribute

### DIFF
--- a/res/layout/incoming.xml
+++ b/res/layout/incoming.xml
@@ -67,7 +67,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@drawable/button_decline"
-                    android:layout_toRightOf="@+id/answerButton"/>
+                    android:layout_toRightOf="@id/answerButton"/>
 
     </RelativeLayout>
 


### PR DESCRIPTION
The `android:layout_toRightOf="@id/answerButton"` for the Decline button was adding a new ID instead of giving the ID of the Answer Button.